### PR TITLE
Use service account for job/cronjob

### DIFF
--- a/charts/helm-rails/Chart.yaml
+++ b/charts/helm-rails/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 0.1.11
+version: 0.1.12
 
 appVersion: 1.0.0

--- a/charts/helm-rails/templates/_cronjob.tpl
+++ b/charts/helm-rails/templates/_cronjob.tpl
@@ -36,7 +36,7 @@ spec:
 {{- if .namespace.secretproviderclass }}
 {{- $_ := set $pod "secretproviderclasses" .namespace.secretproviderclass }}
 {{- end }}
-{{- if .namespace.secretproviderclass }}
+{{- if .namespace.serviceaccount }}
 {{- $_ := set $pod "podserviceaccounts" .namespace.serviceaccount }}
 {{- end }}
 {{- include "pod" $pod | nindent 8 }}

--- a/charts/helm-rails/templates/_job.tpl
+++ b/charts/helm-rails/templates/_job.tpl
@@ -15,7 +15,7 @@ spec:
 {{- if .namespace.secretproviderclass }}
 {{- $_ := set $pod "secretproviderclasses" .namespace.secretproviderclass }}
 {{- end }}
-{{- if .namespace.secretproviderclass }}
+{{- if .namespace.serviceaccount }}
 {{- $_ := set $pod "podserviceaccounts" .namespace.serviceaccount }}
 {{- end }}
 {{- include "pod" $pod | nindent 4 }}

--- a/charts/helm-rails/tests/serviceaccount.bats
+++ b/charts/helm-rails/tests/serviceaccount.bats
@@ -42,6 +42,19 @@ YAML
         containers:
           rails:
             http: {}
+    jobs:
+      example:
+        containers:
+          main:
+            rails: {}
+        restartPolicy: Never
+
+    cronjobs:
+      example:
+        schedule: '*/10 * * * *'
+        containers:
+          main: {}
+        restartPolicy: Never
     namespaces:
       - name: default
         serviceaccount:
@@ -52,6 +65,10 @@ YAML
   assert_no_object 'ServiceAccount' 'example-app-web'
   select_object 'Deployment' 'example-app-web'
   assert_json '.spec.template.spec.serviceAccountName' 'example-app-web'
+  select_object 'Job' 'example-app-example'
+  assert_json '.spec.template.spec.serviceAccountName' 'example-app-web'
+  select_object 'CronJob' 'example-app-example'
+  assert_json '.spec.jobTemplate.spec.template.spec.serviceAccountName' 'example-app-web'
 }
 
 @test "skips a serviceaccount when disabled" {


### PR DESCRIPTION
Currently, the service account will only be applied if a secretproviderclass is specified. This fixes the templates to apply a service account if serviceaccount is specified instead.
