### PR TITLE
update autoscaler version from v2beta2 to v2

### DIFF
--- a/charts/helm-rails/Chart.yaml
+++ b/charts/helm-rails/Chart.yaml
@@ -9,6 +9,6 @@ maintainers:
 
 type: application
 
-version: 0.1.12
+version: 0.1.13
 
 appVersion: 1.0.0

--- a/charts/helm-rails/template-test/helm-rails/templates/service.yaml
+++ b/charts/helm-rails/template-test/helm-rails/templates/service.yaml
@@ -482,7 +482,7 @@ spec:
             secretProviderClass: secretsmanager
 ---
 # Source: helm-rails/templates/service.yaml
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-app-default-worker
@@ -532,7 +532,7 @@ spec:
 ---
 # Source: helm-rails/templates/service.yaml
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: example-app-web

--- a/charts/helm-rails/templates/_hpa.tpl
+++ b/charts/helm-rails/templates/_hpa.tpl
@@ -1,7 +1,7 @@
 {{- define "hpa" -}}
 {{- if .autoscaling.enabled -}}
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "fullname" . }}


### PR DESCRIPTION
See notes about deprecation: 
https://kubernetes.io/blog/2021/12/07/kubernetes-1-23-release-announcement/#horizontalpodautoscaler-v2-graduates-to-ga